### PR TITLE
docs(fly): add Utility Messages for out-of-window sends

### DIFF
--- a/content/fly/reference/questions.md
+++ b/content/fly/reference/questions.md
@@ -609,6 +609,52 @@ Each item in the `vars` array can be:
 This allows you to create arbitrarily complex logical expressions for your wait conditions.
 
 
+## Utility Message
+
+Sends a pre-approved Facebook **Utility Message template** to the user. Use this for notifications that need to reach the user after the 24-hour Messenger window has closed — survey results, prize notifications, reminders.
+
+> Utility Messages are the current replacement for the deprecated Message Tags (`CONFIRMED_EVENT_UPDATE`, etc.) and Recurring Notifications. They require no user opt-in but do require a template that Facebook has approved for your Page.
+
+### Setting it up
+
+First, create the template in the dashboard under **Message Templates**. A template is identified by the tuple **(page, name, language)** — the same template name can exist in multiple independently-approved language variants. Use `{{1}}`, `{{2}}`, etc. in the body for positional placeholders.
+
+Then, in Typeform create a **Statement** question and put this in the description:
+
+```json
+{
+  "type": "utility_message",
+  "keepMoving": true,
+  "template": "results_ready",
+  "language": "en_US",
+  "params": ["{{hidden:name}}", "$5"]
+}
+```
+
+**Fields:**
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `template` | Yes | The template name you created in the dashboard. |
+| `language` | Yes | The exact locale of the approved variant (e.g. `en_US`, `es_LA`, `ha`). No silent default — missing `language` is an error. |
+| `params` | No | Positional array of values substituted into `{{1}}`, `{{2}}`, etc. Supports `{{hidden:X}}` interpolation. |
+
+The `params` array is positional: the first element fills `{{1}}`, the second fills `{{2}}`, and so on. Mismatched counts cause a send-time error, so pass exactly as many params as the approved template has placeholders.
+
+### Typical survey flow
+
+Utility messages are usually sent after a long-running Wait — that's when the 24-hour window matters:
+
+```
+[Consent questions]
+       ↓
+[Wait - timeout: 3 days]
+       ↓
+[Utility Message] "Your {{1}} results are in, {{2}}!"   ← sent outside the 24h window
+```
+
+See [Timeouts]({{< ref "fly/reference/timeouts.md">}}) for timeout setup.
+
 ## Payment
 
 Read about payment question types under [Incentive Payments]({{< ref "fly/reference/incentive_payments.md">}})

--- a/content/fly/reference/questions.md
+++ b/content/fly/reference/questions.md
@@ -624,10 +624,10 @@ Then, in Typeform create a **Statement** question and put this in the descriptio
 ```json
 {
   "type": "utility_message",
-  "keepMoving": true,
   "template": "results_ready",
   "language": "en_US",
-  "params": ["{{hidden:name}}", "$5"]
+  "params": ["{{hidden:name}}", "$5"],
+  "buttons": ["yes", "no"]
 }
 ```
 
@@ -638,8 +638,25 @@ Then, in Typeform create a **Statement** question and put this in the descriptio
 | `template` | Yes | The template name you created in the dashboard. |
 | `language` | Yes | The exact locale of the approved variant (e.g. `en_US`, `es_LA`, `ha`). No silent default — missing `language` is an error. |
 | `params` | No | Positional array of values substituted into `{{1}}`, `{{2}}`, etc. Supports `{{hidden:X}}` interpolation. |
+| `buttons` | No | Positional array of **response values**, one per quick-reply button on the approved template. The user sees the template's approved labels; your survey branches on these values. |
 
 The `params` array is positional: the first element fills `{{1}}`, the second fills `{{2}}`, and so on. Mismatched counts cause a send-time error, so pass exactly as many params as the approved template has placeholders.
+
+### With quick-reply buttons
+
+If the template you approved has quick-reply buttons (up to 3, configured when you created it in the dashboard), you almost certainly want the survey to wait for the user's tap rather than moving on — so **don't** set `keepMoving: true` on this field.
+
+When the user taps a button, the tap arrives like any other multiple-choice quick reply and the field's answer becomes whatever you put in `buttons` for that position. Survey logic jumps then branch on that value exactly like they would for a `multiple_choice` answer:
+
+```
+[Utility Message: results_ready]   buttons: ["yes", "no"]
+       ↓
+   logic jump:
+     if answer equals "yes"  → [show results]
+     if answer equals "no"   → [thank and end]
+```
+
+The button **label** (what the user sees) is locked into the approved template. The **value** (what your logic sees) is whatever string you pass in `buttons` for that index. Most authors make them the same; when they differ, the label is the human-facing word and the value is the machine-facing one.
 
 ### Typical survey flow
 

--- a/content/fly/reference/timeouts.md
+++ b/content/fly/reference/timeouts.md
@@ -85,6 +85,8 @@ Messenger only lets you send a normal message within 24 hours of the user's last
 
 In the dashboard, go to **Message Templates → Create Template**. Pick the page, name the template in `snake_case`, pick a language, and write the body. Use `{{1}}`, `{{2}}`, etc. for any values you will fill in at send time (e.g. the user's name).
 
+**Add quick-reply buttons** if you want users to tap instead of typing — this is almost always what you want, since free text after a long wait creates friction and is hard to branch on. Up to 3 buttons, labels locked at approval.
+
 A template is identified by the tuple **(page, name, language)** — the same name can exist in multiple independently-approved language variants. If your survey runs in multiple languages, create the same template name once per language.
 
 Facebook typically auto-approves custom utility templates in seconds. Wait until the row shows **Approved** before using it.
@@ -96,10 +98,10 @@ Set up your wait step as described above (any timeout over 24 hours), then make 
 ```json
 {
   "type": "utility_message",
-  "keepMoving": true,
   "template": "results_ready",
   "language": "en_US",
-  "params": ["{{hidden:name}}", "$5"]
+  "params": ["{{hidden:name}}", "$5"],
+  "buttons": ["yes", "no"]
 }
 ```
 
@@ -110,5 +112,8 @@ Set up your wait step as described above (any timeout over 24 hours), then make 
 | `template` | Yes | The template name you created in the dashboard. |
 | `language` | Yes | The locale you approved for this template variant (e.g. `en_US`, `es_LA`, `ha`). Must match exactly. No silent default — a missing language is an error. |
 | `params` | No | Positional array of values substituted into `{{1}}`, `{{2}}`, etc. in template order. Supports `{{hidden:X}}` interpolation. |
+| `buttons` | No | Positional array of response values, one per quick-reply button on the approved template. The user sees the template's labels; your survey branches on these values. Omit for text-only templates. |
 
 The `params` array corresponds 1-to-1 with the `{{N}}` placeholders in the body: the first element fills `{{1}}`, the second fills `{{2}}`, and so on. If your template body has 3 placeholders, pass 3 params.
+
+When the template has buttons, leave `keepMoving` off (or `false`) so the survey waits for the user's tap. A tap lands on the field as a normal answer and survey logic jumps can branch on it — see the [Utility Message question type]({{< ref "fly/reference/questions.md">}}#utility-message) for details.

--- a/content/fly/reference/timeouts.md
+++ b/content/fly/reference/timeouts.md
@@ -77,18 +77,38 @@ You then go to the dashboard and under the survey settings (click on the shortco
 
 ## Timeouts over 24 hours
 
-You must ask permission from users to follow up with them after 24 hours on Messenger.
+Messenger only lets you send a normal message within 24 hours of the user's last activity. To send anything after that — survey results, prize notifications, reminders — you need a **Utility Message template**, pre-approved by Facebook for your Page.
 
-If you have done that, you can put the following in the next message and make the timeout > 24 hours:
+> Earlier approaches (Message Tags like `CONFIRMED_EVENT_UPDATE`, and Recurring Notifications) were deprecated by Facebook in early 2026. Utility Messages are the current, globally-available replacement and require **no user opt-in**.
 
-After a timeout, you need to tag the next message as follows:
+### 1. Create the template in the dashboard
 
-JSON:
+In the dashboard, go to **Message Templates → Create Template**. Pick the page, name the template in `snake_case`, pick a language, and write the body. Use `{{1}}`, `{{2}}`, etc. for any values you will fill in at send time (e.g. the user's name).
+
+A template is identified by the tuple **(page, name, language)** — the same name can exist in multiple independently-approved language variants. If your survey runs in multiple languages, create the same template name once per language.
+
+Facebook typically auto-approves custom utility templates in seconds. Wait until the row shows **Approved** before using it.
+
+### 2. Use it in the survey after a long wait
+
+Set up your wait step as described above (any timeout over 24 hours), then make the next field a `utility_message`:
+
 ```json
 {
-    "sendParams": {
-        "tag": "CONFIRMED_EVENT_UPDATE",
-        "messaging_type": "MESSAGE_TAG"
-    }
+  "type": "utility_message",
+  "keepMoving": true,
+  "template": "results_ready",
+  "language": "en_US",
+  "params": ["{{hidden:name}}", "$5"]
 }
 ```
+
+**Fields:**
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `template` | Yes | The template name you created in the dashboard. |
+| `language` | Yes | The locale you approved for this template variant (e.g. `en_US`, `es_LA`, `ha`). Must match exactly. No silent default — a missing language is an error. |
+| `params` | No | Positional array of values substituted into `{{1}}`, `{{2}}`, etc. in template order. Supports `{{hidden:X}}` interpolation. |
+
+The `params` array corresponds 1-to-1 with the `{{N}}` placeholders in the body: the first element fills `{{1}}`, the second fills `{{2}}`, and so on. If your template body has 3 placeholders, pass 3 params.


### PR DESCRIPTION
## Summary

- Replaces the deprecated Message Tag example in `fly/reference/timeouts.md` (under "Timeouts over 24 hours") with guidance on Utility Messages.
- Adds a new `## Utility Message` question type section in `fly/reference/questions.md`.

Facebook deprecated Message Tags in April 2026 and Recurring Notifications globally in February 2026. Utility Messages are the current globally-available replacement — pre-approved templates identified by **(page, name, language)**, no user opt-in required.

Pairs with vlab-research/fly#135.

## Test plan

- [ ] ` hugo server` locally; visit `/fly/reference/timeouts/` and `/fly/reference/questions/` and confirm the new content renders and cross-links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)